### PR TITLE
embed-pdf: add missing site baseurl

### DIFF
--- a/layouts/shortcodes/embed-pdf.html
+++ b/layouts/shortcodes/embed-pdf.html
@@ -27,13 +27,13 @@ window.onload = function() {
 // If absolute URL from the remote server is provided, configure the CORS
 // header on that server.
 
-var url = "{{ .Get "url" }}";
+var url = "{{.Site.BaseURL}}" + "{{ .Get "url" }}";
 
 // Loaded via <script> tag, create shortcut to access PDF.js exports.
 var pdfjsLib = window['pdfjs-dist/build/pdf'];
 
 // The workerSrc property shall be specified.
-pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/pdf-js/build/pdf.worker.js';
+pdfjsLib.GlobalWorkerOptions.workerSrc = "{{.Site.BaseURL}}" + '/js/pdf-js/build/pdf.worker.js';
 
 // Change the Scale value for lower or higher resolution.
 var pdfDoc = null,


### PR DESCRIPTION
To load both "pdf url" and "pdf.worker.js",
the url should be built with "{{.Site.BaseURL}}"

Fixing #3 