### PR TITLE
Fixing Bug with hidePaginator

### DIFF
--- a/layouts/shortcodes/embed-pdf.html
+++ b/layouts/shortcodes/embed-pdf.html
@@ -93,7 +93,7 @@ function queueRenderPage(num) {
 /**
  * Optionally hides the paginator
  */
-if (hidePaginator) {
+if (hidePaginator == "true") {
   document.getElementById("paginator").style.display = 'none';
 }
 


### PR DESCRIPTION
`hidePaginator` was always true before this tiny fix.

This makes sure to hide it only its boolean value is `true`.