### PR TITLE
fix URL and load pdf.js

### DIFF
--- a/layouts/shortcodes/embed-pdf.html
+++ b/layouts/shortcodes/embed-pdf.html
@@ -1,4 +1,5 @@
-<script type="text/javascript" src= '{{"/" | relURL}}/js/pdf-js/build/pdf.js'></script>
+<script type="text/javascript" src='{{"/js/pdf-js/build/pdf.js" | relURL}}'></script>
+
 <style>
 #the-canvas {
   border: 1px solid black;


### PR DESCRIPTION
Hopefully fixes https://github.com/anvithks/hugo-embed-pdf-shortcode/issues/18
I tested both on localhost and deployed.
I'm not familiar with Hugo's `baseUrl` settings, but this PR may at least improve things for a few users

Related https://github.com/anvithks/hugo-embed-pdf-shortcode/issues/26